### PR TITLE
Add "filterNotNull"

### DIFF
--- a/supercharged_dart/lib/iterable/iterable_object.dart
+++ b/supercharged_dart/lib/iterable/iterable_object.dart
@@ -114,6 +114,17 @@ extension IterableSC<T> on Iterable<T> {
     return where(test);
   }
 
+  /// Returns a new [Iterable] with all elements that aren't null
+  ///
+  /// Example:
+  /// ```dart
+  /// [1, 2, null, 4].filterNotNull().toList(); // [1, 2, 4]
+  /// ```
+  ///
+  Iterable<T> filterNotNull() {
+    return where((e) => e != null);
+  }
+
   /// Applies the function [funcIndexValue] to each element of this collection
   /// in iteration order. The function receives the element index as first
   /// parameter [index] and the [element] as the second parameter.

--- a/supercharged_dart/test/iterable/filter_test.dart
+++ b/supercharged_dart/test/iterable/filter_test.dart
@@ -13,4 +13,8 @@ void main() {
             .reduce((value, n) => value + n),
         equals(6));
   });
+
+  test('iterable filterNotNull', () {
+    expect(<int>[1, 2, null, 4].filterNotNull(), equals([1, 2, 4]));
+  });
 }


### PR DESCRIPTION
Useful when you want to get rid of all nulls in an Iterable<T>